### PR TITLE
Remove GSSAPI disabling workaround

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+debathena-ssh-server-config (1.11) unstable; urgency=medium
+
+  * Remove the workaround that disabled GSSAPI if there’s no keytab,
+    because the problem it addressed was only present with
+    GSSAPIKeyExchange=yes clients, the workaround is no longer effective
+    at addressing this problem on any supported releases, and it is
+    incompatible with systemd (Trac: #1562).
+
+ -- Anders Kaseorg <andersk@mit.edu>  Tue, 05 Jul 2016 01:36:38 -0400
+
 debathena-ssh-server-config (1.10) unstable; urgency=low
 
   [ Jonathan Reed ]

--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,7 @@
 DEB_DIVERT_EXTENSION = .debathena
 DEB_DIVERT_FILES_debathena-ssh-server-config += \
 	/etc/ssh/sshd_config.debathena
-DEB_TRANSFORM_FILES_debathena-ssh-server-config += \
+DEB_UNDIVERT_FILES_debathena-ssh-server-config += \
 	/etc/default/ssh.debathena
 include /usr/share/cdbs/1/rules/debhelper.mk
 include /usr/share/cdbs/1/rules/config-package.mk

--- a/debian/transform_ssh.debathena
+++ b/debian/transform_ssh.debathena
@@ -1,7 +1,0 @@
-#!/usr/bin/perl -0p
-s|SSHD_OPTS=|SSHD_OPTS=
-
-\x23 Disable GSSAPI if there's no keytab when sshd is started
-if [ ! -e /etc/krb5.keytab ]; then
-   SSHD_OPTS="\$SSHD_OPTS -o GSSAPIKeyExchange=no -o GSSAPIAuthentication=no"
-fi|x or die;


### PR DESCRIPTION
Remove the workaround that disabled GSSAPI if there’s no keytab, because the problem it addressed was only present with `GSSAPIKeyExchange=yes` clients, the workaround is no longer effective at addressing this problem on any supported releases, and it is incompatible with systemd.
